### PR TITLE
Remove metaPartialSignedDelegateCall

### DIFF
--- a/__snapshots__/Account.test.js
+++ b/__snapshots__/Account.test.js
@@ -1,7 +1,7 @@
 exports['Account externalCall() gas cost 1'] = 49948
 
-exports['Account delegateCall() gas cost 1'] = 35139
+exports['Account delegateCall() gas cost 1'] = 35161
 
-exports['Account metaDelegateCall() gas cost 1'] = 39820
+exports['Account metaDelegateCall() gas cost with unsigned data 1'] = 42600
 
-exports['Account metaPartialSignedDelegateCall() gas cost 1'] = 42617
+exports['Account metaDelegateCall() gas cost with empty unsigned data 1'] = 40911

--- a/__snapshots__/deployAndExecute.test.js
+++ b/__snapshots__/deployAndExecute.test.js
@@ -1,1 +1,1 @@
-exports['DeployAndExecute deploy account and delegate call in one tx gas cost 1'] = 152203
+exports['DeployAndExecute deploy account and delegate call in one tx gas cost 1'] = 153429

--- a/contracts/Account/Account.sol
+++ b/contracts/Account/Account.sol
@@ -57,7 +57,9 @@ contract Account is ProxyGettable, EIP712SignerRecovery {
   /// @param data Call data to include in the delegatecall, signed by the proxyOwner
   /// @param signature Signature of the proxyOwner
   /// @param unsignedData Unsigned call data appended to the delegatecall
-  /// @notice
+  /// @notice WARNING: The `to` contract is responsible for secure handling of the call provided in the encoded
+  /// `callData`. If the proxyOwner signs a metaDelegateCall to a malicious contract, this could result in total loss
+  /// of their account.
   function metaDelegateCall(
     address to, bytes memory data, bytes memory signature, bytes memory unsignedData
   ) external {

--- a/docs/Account/Account.md
+++ b/docs/Account/Account.md
@@ -33,19 +33,11 @@ Only executable directly by the proxy owner
 Makes a delegatecall to an external contract
 
 
-### `metaDelegateCall(address to, bytes data, bytes signature)` (external)
+### `metaDelegateCall(address to, bytes data, bytes signature, bytes unsignedData)` (external)
 
 
 
-Makes a delegatecall to an external contract with message data signed by the proxy owner
-
-
-### `metaPartialSignedDelegateCall(address to, bytes data, bytes signature, bytes unsignedData)` (external)
-
-
-
-Makes a delegatecall to an external contract with message data signed by the proxy owner and unsigned data
-provided by the executor (msg.sender)
+Allows execution of a delegatecall with a valid signature from the proxyOwner
 
 
 

--- a/docs/Account/Account.md
+++ b/docs/Account/Account.md
@@ -35,7 +35,9 @@ Makes a delegatecall to an external contract
 
 ### `metaDelegateCall(address to, bytes data, bytes signature, bytes unsignedData)` (external)
 
-
+WARNING: The `to` contract is responsible for secure handling of the call provided in the encoded
+`callData`. If the proxyOwner signs a metaDelegateCall to a malicious contract, this could result in total loss
+of their account.
 
 Allows execution of a delegatecall with a valid signature from the proxyOwner
 

--- a/test/deployAndExecute.test.js
+++ b/test/deployAndExecute.test.js
@@ -72,7 +72,7 @@ describe('DeployAndExecute', function () {
 
       // data for the tokenToEth swap call
       this.execData = (await this.metaAccountImpl.connect(this.proxyOwner).populateTransaction.metaDelegateCall.apply(this, [
-        ...params, signature
+        ...params, signature, '0x'
       ])).data
 
       // send ETH to undeployed account address


### PR DESCRIPTION
add partial signing support to metaDelegateCall. An empty '0x' bytes can be passed as unsigned data if there is no unsigned data expected for the call. Gas difference is negligible, and this simplifies the Account interface
