### PR TITLE
add metaDelegateCall_EIP1271 function to Account.sol

### DIFF
--- a/__snapshots__/Account.test.js
+++ b/__snapshots__/Account.test.js
@@ -1,7 +1,9 @@
-exports['Account externalCall() gas cost 1'] = 49948
+exports['Account externalCall() gas cost 1'] = 49936
 
-exports['Account delegateCall() gas cost 1'] = 35161
+exports['Account delegateCall() gas cost 1'] = 35183
 
 exports['Account metaDelegateCall() gas cost with unsigned data 1'] = 42600
 
 exports['Account metaDelegateCall() gas cost with empty unsigned data 1'] = 40911
+
+exports['Account metaDelegateCall_EIP1271() gas cost 1'] = 52412

--- a/__snapshots__/deployAndExecute.test.js
+++ b/__snapshots__/deployAndExecute.test.js
@@ -1,1 +1,1 @@
-exports['DeployAndExecute deploy account and delegate call in one tx gas cost 1'] = 153429
+exports['DeployAndExecute deploy account and delegate call in one tx gas cost 1'] = 153424

--- a/contracts/Account/Account.sol
+++ b/contracts/Account/Account.sol
@@ -4,14 +4,20 @@ pragma solidity ^0.7.0;
 
 import "../Proxy/ProxyGettable.sol";
 import "./EIP712SignerRecovery.sol";
+import "./EIP1271Validator.sol";
 
 /// @title Brink account core
 /// @notice Deployed once and used by many Proxy contracts as the implementation contract
-contract Account is ProxyGettable, EIP712SignerRecovery {
+contract Account is ProxyGettable, EIP712SignerRecovery, EIP1271Validator {
   /// @dev Typehash for signed metaDelegateCall() messages
   /// @dev keccak256("MetaDelegateCall(address to,bytes data)")
   bytes32 internal constant META_DELEGATE_CALL_TYPEHASH =
     0x023ce5d01636bb12b4ffde3c4f5a66fb1044aa0dbc251394e60f0a26f1591043;
+
+  /// @dev Typehash for signed metaDelegateCall() messages
+  /// @dev keccak256("MetaDelegateCall_EIP1271(address to,bytes data)")
+  bytes32 internal constant META_DELEGATE_CALL_EIP1271_TYPEHASH =
+    0x1d3b50d88adeb95016e86033ab418b64b7ecd66b70783b0dca7b0afc8bfb8a1e;
 
   /// @dev Constructor sets CHAIN_ID immutable constant
   constructor(uint256 chainId_) EIP712SignerRecovery(chainId_) { }
@@ -52,14 +58,15 @@ contract Account is ProxyGettable, EIP712SignerRecovery {
     }
   }
 
-  /// @dev Allows execution of a delegatecall with a valid signature from the proxyOwner
+  /// @dev Allows execution of a delegatecall with a valid signature from the proxyOwner. Uses EIP-712
+  /// (https://github.com/ethereum/EIPs/pull/712) signer recovery.
   /// @param to Address of the external contract to delegatecall, signed by the proxyOwner
   /// @param data Call data to include in the delegatecall, signed by the proxyOwner
   /// @param signature Signature of the proxyOwner
   /// @param unsignedData Unsigned call data appended to the delegatecall
   /// @notice WARNING: The `to` contract is responsible for secure handling of the call provided in the encoded
-  /// `callData`. If the proxyOwner signs a metaDelegateCall to a malicious contract, this could result in total loss
-  /// of their account.
+  /// `callData`. If the proxyOwner signs a delegatecall to a malicious contract, this could result in total loss of
+  /// their account.
   function metaDelegateCall(
     address to, bytes memory data, bytes memory signature, bytes memory unsignedData
   ) external {
@@ -68,6 +75,35 @@ contract Account is ProxyGettable, EIP712SignerRecovery {
       signature
     );
     require(proxyOwner() == signer, "NOT_OWNER");
+
+    bytes memory callData = abi.encodePacked(data, unsignedData);
+
+    assembly {
+      let result := delegatecall(gas(), to, add(callData, 0x20), mload(callData), 0, 0)
+      if eq(result, 0) {
+        returndatacopy(0, 0, returndatasize())
+        revert(0, returndatasize())
+      }
+    }
+  }
+
+  /// @dev Allows execution of a delegatecall if proxyOwner is a smart contract. Uses EIP-1271
+  /// (https://eips.ethereum.org/EIPS/eip-1271) signer validation.
+  /// @param to Address of the external contract to delegatecall, validated by the proxyOwner contract
+  /// @param data Call data to include in the delegatecall, validated by the proxyOwner contract
+  /// @param signature Signature that will be validated by the proxyOwner contract
+  /// @param unsignedData Unsigned call data appended to the delegatecall
+  /// @notice WARNING: The `to` contract is responsible for secure handling of the call provided in the encoded
+  /// `callData`. If the proxyOwner contract validates a delegatecall to a malicious contract, this could result in
+  /// total loss of the account.
+  function metaDelegateCall_EIP1271(
+    address to, bytes memory data, bytes memory signature, bytes memory unsignedData
+  ) external {
+    require(_isValidSignature(
+      proxyOwner(),
+      keccak256(abi.encode(META_DELEGATE_CALL_EIP1271_TYPEHASH, to, keccak256(data))),
+      signature
+    ), "INVALID_SIGNATURE");
 
     bytes memory callData = abi.encodePacked(data, unsignedData);
 

--- a/contracts/Account/EIP1271Validator.sol
+++ b/contracts/Account/EIP1271Validator.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+
+import "../Interfaces/IERC1271.sol";
+
+/// @title Provides a validation check on a signer contract that implements EIP-1271
+/// @notice https://github.com/ethereum/EIPs/issues/1271
+contract EIP1271Validator {
+
+  // bytes4(keccak256("isValidSignature(bytes32,bytes)")
+  bytes4 constant internal MAGICVALUE = 0x1626ba7e;
+
+  /**
+   * @dev Should return whether the signature provided is valid for the provided hash
+   * @param signer Address of a contract that implements EIP-1271
+   * @param hash Hash of the data to be validated
+   * @param signature Signature byte array associated with hash
+   */ 
+  function _isValidSignature(address signer, bytes32 hash, bytes memory signature) internal view returns (bool) {
+    return IERC1271(signer).isValidSignature(hash, signature) == MAGICVALUE;
+  }
+}

--- a/contracts/Interfaces/IERC1271.sol
+++ b/contracts/Interfaces/IERC1271.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+
+interface IERC1271 {
+  function isValidSignature(bytes32 _hash, bytes memory _signature) external view returns (bytes4 magicValue);
+}

--- a/contracts/Test/MockEIP1271ContractSigner.sol
+++ b/contracts/Test/MockEIP1271ContractSigner.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+
+/// similar to https://github.com/gnosis/safe-contracts/blob/main/contracts/base/FallbackManager.sol to make sure the
+/// Account contract's EIP1271 implementation will work with a GnosisSafe
+contract MockEIP1271ContractSigner {
+  // keccak256("fallback_manager.handler.address")
+  bytes32 internal constant FALLBACK_HANDLER_STORAGE_SLOT = 0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5;
+
+  function setFallbackHandler(address handler) public {
+    bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
+    assembly {
+      sstore(slot, handler)
+    }
+  }
+
+  fallback() external {
+    bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
+    assembly {
+      let handler := sload(slot)
+      if iszero(handler) {
+        return(0, 0)
+      }
+      calldatacopy(0, 0, calldatasize())
+      // The msg.sender address is shifted to the left by 12 bytes to remove the padding
+      // Then the address without padding is stored right after the calldata
+      mstore(calldatasize(), shl(96, caller()))
+      // Add 20 bytes for the address appended add the end
+      let success := call(gas(), handler, 0, 0, add(calldatasize(), 20), 0, 0)
+      returndatacopy(0, 0, returndatasize())
+      if iszero(success) {
+        revert(0, returndatasize())
+      }
+      return(0, returndatasize())
+    }
+  }
+}

--- a/contracts/Test/MockEIP1271Validator.sol
+++ b/contracts/Test/MockEIP1271Validator.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+
+contract ISignatureValidatorConstants {
+  // bytes4(keccak256("isValidSignature(bytes,bytes)")
+  bytes4 internal constant EIP1271_MAGIC_VALUE = 0x20c13b0b;
+}
+
+abstract contract ISignatureValidator is ISignatureValidatorConstants {
+  function isValidSignature(bytes memory _data, bytes memory _signature) public view virtual returns (bytes4);
+}
+
+/// implements some very basic EIP1271 validation for use in tests. Testing it with the backward compat pattern
+/// that GnosisSafe is using just to be extra sure that our Account implementation of EIP1271 checks is compatible.
+/// (https://github.com/gnosis/safe-contracts/blob/main/contracts/handler/CompatibilityFallbackHandler.sol)
+contract MockEIP1271Validator is ISignatureValidator {
+  bytes4 internal constant UPDATED_MAGIC_VALUE = 0x1626ba7e;
+
+  mapping(bytes32 => bool) _validDataHash;
+  mapping(bytes32 => bool) _validSigHashes;
+
+  function isValidSignature(bytes calldata _data, bytes calldata _signature) public view override returns (bytes4) {
+    if (_validDataHash[keccak256(_data)] == true && _validSigHashes[keccak256(_signature)] == true) {
+      return EIP1271_MAGIC_VALUE;
+    } else {
+      return 0xffffffff;
+    }
+  }
+
+  function isValidSignature(bytes32 _dataHash, bytes calldata _signature) public view returns (bytes4) {
+    ISignatureValidator validator = ISignatureValidator(msg.sender);
+    bytes4 value = validator.isValidSignature(abi.encode(_dataHash), _signature);
+    return (value == EIP1271_MAGIC_VALUE) ? UPDATED_MAGIC_VALUE : bytes4(0);
+  }
+
+  function setValidSignature(bytes32 _dataHash, bytes calldata _signature) external {
+    _validDataHash[keccak256(abi.encode(_dataHash))] = true;
+    _validSigHashes[keccak256(_signature)] = true;
+  }
+}

--- a/test/helpers/metaCallDataHash.js
+++ b/test/helpers/metaCallDataHash.js
@@ -1,0 +1,16 @@
+const abi = require('hardhat').ethers.utils.defaultAbiCoder
+const { soliditySha3 } = require('web3-utils')
+
+function metaCallDataHash ({ metaCallTypeHash, to, data }) {
+  return soliditySha3(abi.encode([
+    'bytes32',
+    'address',
+    'bytes32'
+  ], [
+    metaCallTypeHash,
+    to,
+    soliditySha3(data)
+  ]))
+}
+
+module.exports = metaCallDataHash

--- a/test/helpers/setupContractOwnedAccount.js
+++ b/test/helpers/setupContractOwnedAccount.js
@@ -1,0 +1,28 @@
+const { ethers } = require('hardhat')
+const getSigners = require('./getSigners')
+
+const chainId = 1
+
+const setupContractOwnedAccount = async () => {
+  const MockAccount = await ethers.getContractFactory('MockAccount')
+
+  const { proxyDeployer } = await getSigners()
+  const Proxy = (await ethers.getContractFactory('Proxy')).connect(proxyDeployer)
+
+  // mocks GnosisSafe fallback handler to make sure this works with GnosisSafe
+  const MockEIP1271ContractSigner = await ethers.getContractFactory('MockEIP1271ContractSigner')
+  const MockEIP1271Validator = await ethers.getContractFactory('MockEIP1271Validator')
+  const eip1271ContractSigner = await MockEIP1271ContractSigner.deploy()
+  const eip1271Validator = await MockEIP1271Validator.deploy()
+  await eip1271ContractSigner.setFallbackHandler(eip1271Validator.address)
+
+  const proxyOwner = await MockEIP1271Validator.attach(eip1271ContractSigner.address)
+
+  const canonicalAccount = await MockAccount.deploy(chainId)
+  const proxy = await Proxy.deploy(canonicalAccount.address, proxyOwner.address)
+  const contractOwnedAccount = await ethers.getContractAt('MockAccountWithTestCalls', proxy.address)
+
+  return { contractOwnedAccount, account: canonicalAccount, proxyOwner }
+}
+
+module.exports = setupContractOwnedAccount


### PR DESCRIPTION
this adds support for smart contracts as the account proxyOwner, as long as the proxyOwner implements EIP-1271 `isValidSignature`. The primary use case for adding this is to support GnosisSafe contracts as Brink signers.

The metaDelegateCall function exists to provide support for EOA signers. metaDelegateCall_EIP1271 won't work for EOA signers, it can only be used if the proxyOwner is a smart contract.