### PR TITLE
Audit Issue 8: Removing immutable chain id

### DIFF
--- a/contracts/Account/Account.sol
+++ b/contracts/Account/Account.sol
@@ -18,8 +18,7 @@ contract Account is ProxyGettable, EIP712SignerRecovery, EIP1271Validator {
   bytes32 internal constant META_DELEGATE_CALL_EIP1271_TYPEHASH =
     0x1d3b50d88adeb95016e86033ab418b64b7ecd66b70783b0dca7b0afc8bfb8a1e;
 
-  /// @dev Constructor sets CHAIN_ID immutable constant
-  constructor(uint256 chainId_) EIP712SignerRecovery(chainId_) { }
+  constructor() EIP712SignerRecovery() { }
 
   /// @dev Loads bytes32 data stored at the given pointer
   /// @param ptr The pointer to the bytes32 data

--- a/contracts/Account/EIP712SignerRecovery.sol
+++ b/contracts/Account/EIP712SignerRecovery.sol
@@ -6,13 +6,7 @@ import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 /// @title Provides signer address recovery for EIP-712 signed messages
 /// @notice https://github.com/ethereum/EIPs/pull/712
 contract EIP712SignerRecovery {
-
-  uint256 internal immutable CHAIN_ID;
-
-  constructor (uint256 chainId_) {
-    CHAIN_ID = chainId_;
-  }
-
+  
   /// @dev Recovers the signer address for an EIP-712 signed message
   /// @param dataHash Hash of the data included in the message
   /// @param signature An EIP-712 signature
@@ -25,7 +19,7 @@ contract EIP712SignerRecovery {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
         keccak256("BrinkAccount"),
         keccak256("1"),
-        CHAIN_ID,
+        this.getChainId(),
         address(this)
       )),
       dataHash
@@ -33,5 +27,14 @@ contract EIP712SignerRecovery {
 
     // recover the signer address from the signed messageHash and return
     signer = ECDSA.recover(messageHash, signature);
+  }
+
+  /// @dev Gets the current chain id
+  function getChainId() public pure returns (uint256 chainId) {
+    uint256 id;
+    assembly {
+        id := chainid()
+    }
+    return id;
   }
 }

--- a/contracts/Test/MockAccount.sol
+++ b/contracts/Test/MockAccount.sol
@@ -8,7 +8,7 @@ contract MockAccount is Account {
   // keccak256("MockAccount.mockBlockNum") : Storage pointer to mockBlockNum address
   bytes32 internal constant _mockBlockNumPtr = 0x309cc50dd5fa3f2b7dda8552a2789bf8dec0e6e9d7bce3582758e21eab93e630;
   
-  constructor (uint256 chainId_) Account(chainId_) {}
+  constructor () Account() {}
 
   // override so we can mock the current block number,
   // since mining blocks on ganache is too slow for the tests

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -6,8 +6,6 @@ const { BN18 } = brinkUtils.constants
 const { deployTestTokens } = brinkUtils.testHelpers(ethers)
 const { setupDeployers, snapshotGas } = require('./helpers')
 
-const chainId = 1
-
 describe('Proxy', function () {
   beforeEach(async function () {
     const [defaultAccount, proxyOwner] = await ethers.getSigners()
@@ -16,7 +14,7 @@ describe('Proxy', function () {
     this.Proxy = await ethers.getContractFactory('Proxy')
     this.Account = await ethers.getContractFactory('Account')
 
-    this.metaAccountImpl = await this.Account.deploy(chainId)
+    this.metaAccountImpl = await this.Account.deploy()
 
     const { singletonFactory, singletonFactoryCaller } = await setupDeployers()
     this.singletonFactory = singletonFactory

--- a/test/deployAndExecute.test.js
+++ b/test/deployAndExecute.test.js
@@ -6,8 +6,6 @@ const { BN18 } = brinkUtils.constants
 const { signMetaTx, deployTestTokens } = brinkUtils.testHelpers(ethers)
 const { setupDeployers, getSigners, snapshotGas } = require('./helpers')
 
-const chainId = 1
-
 describe('DeployAndExecute', function () {
   beforeEach(async function () {
     const signers = await getSigners()
@@ -19,7 +17,7 @@ describe('DeployAndExecute', function () {
     this.Account = await ethers.getContractFactory('Account')
     this.testAccountCalls = await ethers.getContractFactory('TestAccountCalls')
 
-    this.metaAccountImpl = await this.Account.deploy(chainId)
+    this.metaAccountImpl = await this.Account.deploy()
     this.salt = ethers.utils.formatBytes32String('some.salt')
     
     const { singletonFactory, deployAndExecute } = await setupDeployers()

--- a/test/helpers/setupContractOwnedAccount.js
+++ b/test/helpers/setupContractOwnedAccount.js
@@ -1,8 +1,6 @@
 const { ethers } = require('hardhat')
 const getSigners = require('./getSigners')
 
-const chainId = 1
-
 const setupContractOwnedAccount = async () => {
   const MockAccount = await ethers.getContractFactory('MockAccount')
 
@@ -18,7 +16,7 @@ const setupContractOwnedAccount = async () => {
 
   const proxyOwner = await MockEIP1271Validator.attach(eip1271ContractSigner.address)
 
-  const canonicalAccount = await MockAccount.deploy(chainId)
+  const canonicalAccount = await MockAccount.deploy()
   const proxy = await Proxy.deploy(canonicalAccount.address, proxyOwner.address)
   const contractOwnedAccount = await ethers.getContractAt('MockAccountWithTestCalls', proxy.address)
 

--- a/test/helpers/setupMetaAccount.js
+++ b/test/helpers/setupMetaAccount.js
@@ -1,8 +1,6 @@
 const { ethers } = require('hardhat')
 const getSigners = require('./getSigners')
 
-const chainId = 1
-
 const setupMetaAccount = async (owner) => {
   const MockAccount = await ethers.getContractFactory('MockAccount')
 
@@ -11,7 +9,7 @@ const setupMetaAccount = async (owner) => {
 
   const proxyAccountOwner = owner || metaAccountOwner
 
-  const canonicalAccount = await MockAccount.deploy(chainId)
+  const canonicalAccount = await MockAccount.deploy()
   const proxy = await Proxy.deploy(canonicalAccount.address, proxyAccountOwner.address)
   const metaAccount = await ethers.getContractAt('MockAccountWithTestCalls', proxy.address)
 


### PR DESCRIPTION
WARNING: Some tests fail, needs to be looked at

NOTE: If we upgrade to solidity 0.8.0 we can get some gas savings here by using block.chainId 