### PR TITLE
Add custom errors, feature supported in solidity 8

### DIFF
--- a/__snapshots__/Account.test.js
+++ b/__snapshots__/Account.test.js
@@ -4,4 +4,4 @@ exports['Account delegateCall() gas cost 1'] = 32262
 
 exports['Account metaDelegateCall() gas cost 1'] = 39464
 
-exports['Account metaDelegateCall_EIP1271() gas cost 1'] = 52144
+exports['Account metaDelegateCall_EIP1271() gas cost 1'] = 52147


### PR DESCRIPTION
negligible gas increase for `metaDelegateCall_EIP1271()`, but provides useful dynamic error data on revert