### PR TITLE
Align data location of interface with implementation

### DIFF
--- a/contracts/Test/MockEIP1271Validator.sol
+++ b/contracts/Test/MockEIP1271Validator.sol
@@ -20,7 +20,7 @@ contract MockEIP1271Validator is ISignatureValidator {
   mapping(bytes32 => bool) _validDataHash;
   mapping(bytes32 => bool) _validSigHashes;
 
-  function isValidSignature(bytes calldata _data, bytes calldata _signature) public view override returns (bytes4) {
+  function isValidSignature(bytes memory _data, bytes memory _signature) public view override returns (bytes4) {
     if (_validDataHash[keccak256(_data)] == true && _validSigHashes[keccak256(_signature)] == true) {
       return EIP1271_MAGIC_VALUE;
     } else {


### PR DESCRIPTION
The reason behind the PR has already been explained well by @chriseth in a similar PR to OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3293) so I'll copy that description here:

> First, I would like to apologize. Somehow the issue [ethereum/solidity#10900](https://github.com/ethereum/solidity/issues/10900) got lost in our backlog. We are currently fixing it and discovered one instance of this in openzeppelin. This PR fixes it.
> 
> More details:
> 
> The function `hashProposal` in the interface is declared with `calldata` parameters while its implementation in Governor uses `memory`. This leads to invalid code being generated whenever someone calls the `hashProposal` function internally on the interface instead of the implementation. This can only happen if you have an (abstract) contract that inherits from the interface, but not from the implementation, but is still part of an inheritance hierarchy that also has the implementation.
> 
> Simplified example:
> 
> ```solidity
> abstract contract I {
>         function f(uint[] calldata x)  virtual internal;
> }
> contract C is I {
>         uint public data;
>         // The override checker in the compiler does not complain
>         // here - this is the bug in the compiler.
>         function f(uint[] memory x)  override internal {
>                 data = x[0];
>         }
> }
> abstract contract D is I {
>         function g(uint[] calldata x)  external {
>                 // Since D only "knows" `I`, the signature of `f` uses calldata,
>                 // while the virtual lookup ends up with `C.f`, which uses memory.
>                 // This results in the calldata pointer `x` being passed and interpreted
>                 // as a memory pointer.
>                 f(x);
>         }
> }
> contract X is C, D { }
> ```

In case of Brink, the function in question is `isValidSignature` from `ISignatureValidator`.